### PR TITLE
docs(repository): Switch to new repository schema

### DIFF
--- a/.repository/index.yaml
+++ b/.repository/index.yaml
@@ -1,0 +1,19 @@
+slug: docker-tflint
+description: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
+project: cardboardci
+namespace: docker
+status: archived
+icon: icon.svg
+license:
+  type: MIT
+  content: Jonathan Beverly <jrbeverly>
+  year: 2019
+topics: |-
+  [
+    "dockerfile",
+    "terraform",
+    "tflint",
+    "linter",
+    "hcl",
+    "aws"
+  ]


### PR DESCRIPTION
Adopt new repository schema, switching to YAML.

This removes the old JSON + repository schema, switching to using YAML and a project oriented schema. The new project field makes the root of a project clear.

Additionally the language field has been removed as it was a fairly dynamic field.